### PR TITLE
which依存を基本的になくして、PATHやexec-pathも考慮するように

### DIFF
--- a/perlbrew.el
+++ b/perlbrew.el
@@ -35,8 +35,13 @@
 
 ;;; Code:
 
+(defgroup perlbrew nil
+  "perlbrew"
+  :group 'perlbrew)
+
 (defcustom perlbrew-dir (concat (getenv "HOME") "/perl5/perlbrew")
-  "your perlbrew directory")
+  "your perlbrew directory"
+  :group 'perlbrew)
 
 (defvar perlbrew-perls-dir nil)
 (defvar perlbrew-command-path nil)


### PR DESCRIPTION
元々のやつだとperlbrew-switchしてもperlが切り替わらない問題があったので、修正しました。
## 変更点
- perlbrew配下のperlを使うときはwhich 依存をなくす
  - perlbrew-dirに指定されたものからperlへのpathを組み立てるように
  - system perlを選択した時のみ、which perlで探す
- PATHやexec-pathを考慮するように
  - PATHやexec-pathを変えないと、その他のelispのshellでperlを呼び出すときにうまく行かなくなるため
- custom変数の導入
  - perlbrewのdirectoryを指定できるように
- perlbrew-useというのを切り替えるときの関数名に
  - perlbrew-switchは適切でないと思ったので、変えました。perlbrew-switchはperlbrew-useを呼ぶという形で残しています
