### PR TITLE
Fix from corrected by syohex

### DIFF
--- a/perlbrew.el
+++ b/perlbrew.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2011 Kentaro Kuribayashi
 
 ;; Author: Kentaro Kuribayashi <kentarok@gmail.com>
-;; Version: 0.2
+;; Version: 0.3
 ;; Keywords: Emacs, Perl
 
 ;; This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
some fix from corrected. For details, see http://d.hatena.ne.jp/syohex/20130120/1358647901.
- fix defgroup definition
- add checking valid perl path
- some refactoring
- remove useless functions
- add buffer local variables, for avoiding warnings
